### PR TITLE
When printing length spectrum, restrict to 9 decimals behind the point for nice formatting.

### DIFF
--- a/cython/core/basic.pyx
+++ b/cython/core/basic.pyx
@@ -820,17 +820,26 @@ LengthSpectrumFormatStringWithWord = (
 
 class LengthSpectrumInfo(Info):
     def __repr__(self):
+        lenStr = "%12.9f" % self.length.real()
+        absImag = abs(self.length.imag())
+        if absImag > 1e-9:
+            if self.length.imag() > 0:
+                lenStr += " + "
+            else:
+                lenStr += " - "
+            lenStr += "%12.9f*I" % absImag
+
         if 'word' in self:
             return LengthSpectrumFormatStringWithWord % (
                 self.multiplicity,
-                self.length,
+                lenStr,
                 self.topology,
                 self.parity,
                 self.word)
         else:
             return LengthSpectrumFormatString % (
                 self.multiplicity,
-                self.length,
+                lenStr,
                 self.topology,
                 self.parity )
 
@@ -849,10 +858,10 @@ class LengthSpectrum(list):
     def __repr__(self):
         if len(self) > 0 and 'word' in self[0]:
             base = LengthSpectrumFormatStringWithWord % (
-                'mult', 'length', 'topology', 'parity', 'word')
+                'mult', ' length', 'topology', 'parity', 'word')
         else:
             base = LengthSpectrumFormatString % (
-                'mult', 'length', 'topology', 'parity')
+                'mult', ' length', 'topology', 'parity')
         return '\n'.join([base] + [repr(s) for s in self])
 
 class ListOnePerLine(list):

--- a/cython/core/basic.pyx
+++ b/cython/core/basic.pyx
@@ -806,7 +806,7 @@ def _StrLongestLen(l):
 
 LengthSpectrumFormatStringBase = (
     '%-4s '                                   # Multiplicity
-    '%-32s '                                  # Length
+    '%-40s '                                  # Length
     '%-' + _StrLongestLen(Orbifold1) + 's ')  # Topology
 
 LengthSpectrumFormatString = (
@@ -815,33 +815,35 @@ LengthSpectrumFormatString = (
 
 LengthSpectrumFormatStringWithWord = (
     LengthSpectrumFormatStringBase +
-    '%-' + _StrLongestLen(MatrixParity) +'s ' # Parity
+    '%-6s '                                   # Parity
     '%s')                                     # Word
+
+ShortMatrixParity = { MatrixParity[0] : '-', MatrixParity[1] : '+' }
 
 class LengthSpectrumInfo(Info):
     def __repr__(self):
-        lenStr = "%12.9f" % self.length.real()
+        lenStr = "%17.14f" % self.length.real()
         absImag = abs(self.length.imag())
         if absImag > 1e-9:
             if self.length.imag() > 0:
                 lenStr += " + "
             else:
                 lenStr += " - "
-            lenStr += "%12.9f*I" % absImag
+            lenStr += "%17.14f*I" % absImag
 
         if 'word' in self:
             return LengthSpectrumFormatStringWithWord % (
                 self.multiplicity,
                 lenStr,
                 self.topology,
-                self.parity,
+                ShortMatrixParity[self.parity],
                 self.word)
         else:
             return LengthSpectrumFormatString % (
                 self.multiplicity,
                 lenStr,
                 self.topology,
-                self.parity )
+                ShortMatrixParity[self.parity] )
 
 class ShapeInfo(Info):
     _obsolete = {'precision' : 'accuracies'}

--- a/cython/core/manifold.pyx
+++ b/cython/core/manifold.pyx
@@ -1418,9 +1418,9 @@ cdef class Manifold(Triangulation):
 
         >>> L = Manifold("m004").length_spectrum(1.1, include_words = True)
         >>> L
-        mult  length                          topology     parity                 word
-        1     1.087070145 -  1.722768450*I    circle       orientation-preserving a
-        1     1.087070145 +  1.722768450*I    circle       orientation-preserving bC
+        mult  length                                  topology     parity word
+        1     1.08707014499574 -  1.72276844987009*I  circle       +      a
+        1     1.08707014499574 +  1.72276844987009*I  circle       +      bC
 
         Access just the length:
        

--- a/cython/core/manifold.pyx
+++ b/cython/core/manifold.pyx
@@ -1417,10 +1417,15 @@ cdef class Manifold(Triangulation):
         Here's a quick example:
 
         >>> L = Manifold("m004").length_spectrum(1.1, include_words = True)
-        >>> L # doctest: +NUMERIC6
-        mult length                           topology      parity word
-        1    1.087070144995739 - 1.722768449870090*I circle        orientation-preserving a
-        1    1.087070144995739 + 1.722768449870090*I circle        orientation-preserving bC
+        >>> L
+        mult  length                          topology     parity                 word
+        1     1.087070145 -  1.722768450*I    circle       orientation-preserving a
+        1     1.087070145 +  1.722768450*I    circle       orientation-preserving bC
+
+        Access just the length:
+       
+        >>> L[0].length # doctest: +NUMERIC6
+        1.08707014499574 - 1.72276844987009*I
 
         """
         args = (cutoff, full_rigor, grouped, include_words)


### PR DESCRIPTION
Since this decreasing the precision shown to a user, I figured Nathan or Marc want to have a look before I check it in.