### PR TITLE
fix E401 (avoid multiple imports on one line)

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import os, sys, re, tempfile, time, png, webbrowser, time, signal
+import os
+import sys
+import re
+import time
 from collections.abc import Mapping  # Python 3.5 or newer
 from IPython.core.displayhook import DisplayHook
 

--- a/python/app_menus.py
+++ b/python/app_menus.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-import sys, os, webbrowser
+import sys
+import os
+import webbrowser
 from urllib.request import pathname2url
 from .gui import *
 from . import __file__ as snappy_dir

--- a/python/browser.py
+++ b/python/browser.py
@@ -571,9 +571,10 @@ class Browser(Tk_.Toplevel):
 
     def update_aka(self):
         self._write_aka_info()
-        #self.identifier.identify(self.manifold)
-        #self.aka_after_id = self.after(100, self._aka_callback)
+        # self.identifier.identify(self.manifold)
+        # self.aka_after_id = self.after(100, self._aka_callback)
         M = self.manifold.copy()
+
         def format_name(N):
             if all(N.cusp_info('is_complete')):
                 return N.name()

--- a/python/database.py
+++ b/python/database.py
@@ -14,15 +14,21 @@ and returns a list of subclasses of "ManifoldTable".
 from .db_utilities import decode_torsion, decode_matrices, db_hash
 from .sage_helper import _within_sage
 from spherogram.codecs import DTcodec
-import sys, sqlite3, re, os, random, importlib, collections
+import sys
+import sqlite3
+import re
+import random
+import importlib
+import collections
 
 if _within_sage:
     import sage.all
+
     def is_int(slice):
-        return isinstance(slice, (sage.all.Integer,int))
+        return isinstance(slice, (sage.all.Integer, int))
 
     def is_int_or_none(slice):
-        return isinstance(slice, (sage.all.Integer,int, type(None)))
+        return isinstance(slice, (sage.all.Integer, int, type(None)))
 
     def is_float_or_none(slice):
         return isinstance(slice, (float, sage.all.RealDoubleElement,

--- a/python/decorated_isosig.py
+++ b/python/decorated_isosig.py
@@ -45,7 +45,8 @@ multiple change-of-basis matrices that yield combinatorially
 isomorphic pairs (triangulation, peripheral curves).  In such cases,
 the decoration is the lexicographically first one.
 """
-import re, string
+import re
+import string
 
 # Used between the base isosig and the decorated version.
 separator = '_'

--- a/python/gui.py
+++ b/python/gui.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import os, sys, time, tempfile, png
+import os
+import sys
+import time
+import tempfile
 import tkinter as Tk_
 from tkinter import ttk as ttk
 from tkinter.font import Font, families as font_families

--- a/python/infodialog.py
+++ b/python/infodialog.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-import sys, os, datetime
+import sys
+import os
+import datetime
 from .gui import *
 from .version import version as SnapPy_version
 from IPython import __version__ as IPython_version

--- a/python/numeric_output_checker.py
+++ b/python/numeric_output_checker.py
@@ -31,7 +31,9 @@ class NumericExample:
 
     """
 
-import doctest, re, decimal
+import doctest
+import re
+import decimal
 
 # Generate flags NUMERIC6, ...
 

--- a/python/preferences.py
+++ b/python/preferences.py
@@ -1,4 +1,5 @@
-import os, sys, re, time
+import os
+import sys
 try:
     import plistlib
 except ImportError:

--- a/python/ptolemy/test.py
+++ b/python/ptolemy/test.py
@@ -20,7 +20,8 @@ from snappy.ptolemy.coordinates import PtolemyCannotBeCheckedError
 from snappy.sage_helper import _within_sage, doctest_modules
 from snappy.pari import pari
 import bz2
-import os, sys
+import os
+import sys
 
 if _within_sage:
     from sage.misc.sage_eval import sage_eval

--- a/python/sage_helper.py
+++ b/python/sage_helper.py
@@ -11,16 +11,21 @@ than the usual ">>>".
 try:
     import sage.all
     _within_sage = True
-except:
+except ImportError:
     _within_sage = False
     import decorator
 
-import sys, doctest, re, types
+import sys
+import doctest
+import re
+import types
 
 from .numeric_output_checker import NumericOutputChecker
 
+
 class SageNotAvailable(Exception):
     pass
+
 
 if _within_sage:
     def sage_method(function):

--- a/python/snap/__init__.py
+++ b/python/snap/__init__.py
@@ -26,6 +26,7 @@ def tetrahedra_field_gens(manifold):
             return polished_tetrahedra_shapes(manifold, bits_prec=prec)
     else:
         double_cover = manifold.orientation_cover()
+
         def func(prec):
             return polished_tetrahedra_shapes(double_cover, bits_prec=prec)[::2]
     return ListOfApproximateAlgebraicNumbers(func)

--- a/python/snap/find_field.py
+++ b/python/snap/find_field.py
@@ -135,6 +135,7 @@ class ApproximateAlgebraicNumber():
     def __add__(self, other):
         if not isinstance(other, ApproximateAlgebraicNumber):
             raise ValueError
+
         def f(prec):
             return self(prec) + other(prec)
         return ApproximateAlgebraicNumber(f)
@@ -142,6 +143,7 @@ class ApproximateAlgebraicNumber():
     def __mul__(self, other):
         if not isinstance(other, ApproximateAlgebraicNumber):
             raise ValueError
+
         def f(prec):
             return self(prec)*other(prec)
         return ApproximateAlgebraicNumber(f)
@@ -149,6 +151,7 @@ class ApproximateAlgebraicNumber():
     def __div__(self, other):
         if not isinstance(other, ApproximateAlgebraicNumber):
             raise ValueError
+
         def f(prec):
             return self(prec)/other(prec)
         return ApproximateAlgebraicNumber(f)
@@ -181,9 +184,11 @@ class ExactAlgebraicNumber(ApproximateAlgebraicNumber):
     @cached_method
     def __call__(self, prec):
         roots = [r[0] for r in self._min_poly.roots(ComplexField(prec))]
+
         def dist_to_defining_root(z):
             return abs(z - self._approx_root)
         return sorted(roots, key=dist_to_defining_root)[0]
+
 
 def optimize_field_generator(z):
     p = z.min_polynomial()

--- a/python/snap/nsagetools.py
+++ b/python/snap/nsagetools.py
@@ -1,8 +1,7 @@
 """
 Tools for use in Sage.
 """
-
-import os, sys, re, string, tempfile
+import string
 from ..sage_helper import _within_sage, sage_method
 
 if _within_sage:

--- a/python/snap/peripheral/peripheral.py
+++ b/python/snap/peripheral/peripheral.py
@@ -67,7 +67,7 @@ def peripheral_curve_package(snappy_manifold):
     A = matrix([[alpha(meridian), beta(meridian)], [alpha(longitude), beta(longitude)]])
     assert abs(A.det()) == 1
     Ainv = A.inverse().change_ring(ZZ)
-    B = Ainv.transpose()*matrix(ZZ, [alpha.weights, beta.weights])
+    B = Ainv.transpose() * matrix(ZZ, [alpha.weights, beta.weights])
     mstar = dual_cellulation.OneCocycle(D, list(B[0]))
     lstar = dual_cellulation.OneCocycle(D, list(B[1]))
     AA = matrix([[mstar(meridian), lstar(meridian)], [mstar(longitude), lstar(longitude)]])
@@ -78,6 +78,7 @@ def peripheral_curve_package(snappy_manifold):
     N.cusp_dual_cellulation = D
     D.meridian, D.longitude = meridian, longitude
     D.meridian_star, D.longitude_star = mstar, lstar
+
     def slope(onecycle):
         return vector([D.meridian_star(onecycle), D.longitude_star(onecycle)])
     D.slope = slope

--- a/python/snap/peripheral/test.py
+++ b/python/snap/peripheral/test.py
@@ -19,7 +19,7 @@ def verbose():
 def doctest_globals(module):
     if hasattr(module, 'doctest_globals'):
         return module.doctest_globals()
-    return {}
+    return dict()
 
 
 if __name__ == '__main__':
@@ -27,12 +27,9 @@ if __name__ == '__main__':
     for module in modules:
         print(module.__name__)
         result = doctest.testmod(module,
-                                 extraglobs= doctest_globals(module),
+                                 extraglobs=doctest_globals(module),
                                  verbose=verbose())
-        print(4*' ' + repr(result))
+        print(4 * ' ' + repr(result))
         failed += result.failed
         attempted += result.attempted
     print('\nAll doctests:\n    %s failures out of %s tests.' % (failed, attempted))
-
-
-

--- a/python/snap/peripheral/test.py
+++ b/python/snap/peripheral/test.py
@@ -1,8 +1,10 @@
-import sys, getopt
+import sys
+import getopt
 import doctest
 
 from . import dual_cellulation, link, peripheral, surface
 modules = [dual_cellulation, link, peripheral, surface]
+
 
 def verbose():
     try:
@@ -13,11 +15,12 @@ def verbose():
         verbose = False
     return verbose
 
+
 def doctest_globals(module):
     if hasattr(module, 'doctest_globals'):
         return module.doctest_globals()
-    else:
-        return dict()
+    return {}
+
 
 if __name__ == '__main__':
     failed, attempted = 0, 0

--- a/python/snap/polished_reps.py
+++ b/python/snap/polished_reps.py
@@ -2,9 +2,7 @@
 A Sage module for finding the holonomy representation of a hyperbolic
 3-manifold to very high precision.
 """
-import os, sys, re, string, tempfile
 from itertools import product, chain
-from functools import reduce
 from ..sage_helper import _within_sage
 from ..math_basics import prod
 from ..pari import pari

--- a/python/snap/t3mlite/files.py
+++ b/python/snap/t3mlite/files.py
@@ -8,7 +8,7 @@
 from .arrow import eArrow
 from .simplex import *
 from .tetrahedron import Tetrahedron
-import os, sys, re
+import re
 
 # Nathan's code for importing and exporting snappea files.
 # Converts a SnapPea file to MComplex.  Doesn't really use all the
@@ -19,7 +19,7 @@ import os, sys, re
 #      2    5    1   34
 #   3120 0321 0132 0132
 
-def read_SnapPea_file(file_name=None, data = None):
+def read_SnapPea_file(file_name=None, data=None):
     if data is None:
         data = open(file_name).read().decode('ascii')
     count = 0

--- a/python/snap/t3mlite/mcomplex.py
+++ b/python/snap/t3mlite/mcomplex.py
@@ -18,7 +18,9 @@ from .perm4 import Perm4, inv
 from . import files
 from . import linalg
 from . import homology
-import os, sys, random, io, itertools
+import sys
+import random
+import io
 
 try:
     import snappy

--- a/python/snap/t3mlite/spun.py
+++ b/python/snap/t3mlite/spun.py
@@ -6,13 +6,15 @@ of it (though depending very much on snappy), except for borrowing
 some linear algebra code.
 """
 
-import snappy, FXrays
+import snappy
+import FXrays
 if snappy._within_sage:
     from sage.all import gcd
     from sage.all import vector as Vector
     from sage.all import matrix as Matrix
 else:
     from snappy.snap.t3mlite.linalg import Vector, Matrix, gcd
+
 
 def weak_normalize_slope(slope):
     """For a tuple (a, b), scale it so that gcd(a,b)=1"""
@@ -22,6 +24,7 @@ def weak_normalize_slope(slope):
     g = gcd(a,b)
     a, b = a//g, b//g
     return (a,b)
+
 
 def normalize_slope(slope):
     """
@@ -46,6 +49,7 @@ def normalize_slope(slope):
     elif a == 0 and b < 0:
         b = -b
     return (a,b)
+
 
 def shift_matrix(n):
     """

--- a/python/snap/test.py
+++ b/python/snap/test.py
@@ -2,7 +2,8 @@ from ..sage_helper import _within_sage, doctest_modules
 from ..pari import pari
 import snappy
 import snappy.snap as snap
-import doctest, collections, getopt, sys
+import getopt
+import sys
 
 
 def _test_gluing_equations(manifold, shapes):
@@ -10,7 +11,7 @@ def _test_gluing_equations(manifold, shapes):
     Given a manifold and exact shapes, test whether the rectangular gluing
     equations are fulfilled.
     """
-    one_minus_shapes = [ 1 - shape for shape in shapes ]
+    one_minus_shapes = [1 - shape for shape in shapes]
     for A, B, c in manifold.gluing_equations('rect'):
         val = c
         for a, shape in zip(A, shapes):
@@ -20,6 +21,7 @@ def _test_gluing_equations(manifold, shapes):
         if not val == 1:
             return False
     return True
+
 
 def test_polished(dec_prec=200):
     def test_manifold(manifold):

--- a/python/test.py
+++ b/python/test.py
@@ -1,4 +1,5 @@
-import doctest, inspect, os, sys, getopt, collections
+import sys
+import getopt
 import snappy
 import snappy.snap.test
 import spherogram.test


### PR DESCRIPTION
as another step towards making "sage --tox -e pycodestyle-minimal python/" pass

This command is passing on the sage code base itself, and is checking only a small subset of pycodestyle errors.