### PR TITLE
removing some unused variables in cython code

### DIFF
--- a/cython/core/basic.pyx
+++ b/cython/core/basic.pyx
@@ -738,7 +738,6 @@ class Isometry():
 cdef IsometryListToIsometries(IsometryList *isometries):
     cdef int n, c, i, j, c_cusp_image
     cdef MatrixInt22  c_cusp_map
-    cdef Boolean extends
     n = isometry_list_size(isometries)
     c = isometry_list_num_cusps(isometries)
 

--- a/cython/core/fundamental_group.pyx
+++ b/cython/core/fundamental_group.pyx
@@ -52,18 +52,15 @@ cdef int_to_gen_string(int g, int num_generators, verbose_form):
             ans = 'x' if g > 0 else 'X'
             return ans + '%d' % abs(g)
 
+
 def _letter_seperator(verbose_form):
-    if verbose_form:
-        return '*'
-    else:
-        return ''
+    return '*' if verbose_form else ''
+
 
 cdef c_word_as_string(int *word, int num_generators, verbose_form):
     cdef int n = 0
-    cdef int letter
     word_list = []
     while word[n] != 0:
-        letter = word[n]
         word_list.append(
             int_to_gen_string(word[n], num_generators, verbose_form))
         n += 1

--- a/cython/core/manifold.pyx
+++ b/cython/core/manifold.pyx
@@ -197,7 +197,6 @@ cdef class Manifold(Triangulation):
 
         cdef Boolean *c_opacities
         cdef c_Triangulation *c_retriangulated_triangulation
-        cdef char *c_string
         cdef int n = get_num_tetrahedra(self.c_triangulation)
         cdef result
         cdef Triangulation new_tri
@@ -685,8 +684,6 @@ cdef class Manifold(Triangulation):
         True
         """
         cdef const_char_ptr err_msg=NULL
-        cdef c_Triangulation* copy_c_triangulation
-        cdef c_Triangulation
         if self.c_triangulation is NULL:
             raise ValueError('The Triangulation is empty.')
 
@@ -1321,9 +1318,8 @@ cdef class Manifold(Triangulation):
           >>> M
           m125(0,0)(-1,-2)
         """
-        cdef int a,b,c,d
+        cdef int d
         cdef MatrixInt22 *matrices
-        cdef c_FuncResult result 
 
         if self.c_triangulation is NULL:
             raise ValueError('The Triangulation is empty')
@@ -1761,7 +1757,7 @@ cdef class Manifold(Triangulation):
         """
         cdef NormalSurfaceList *surfaces
         cdef c_FuncResult result
-        cdef int num_surfaces, i
+        cdef int num_surfaces
         cdef c_Triangulation  *pieces[2]
         cdef Manifold M0, M1
         
@@ -1832,7 +1828,6 @@ cdef class Manifold(Triangulation):
 
     def _cusp_cross_section_info(self):
         cdef c_Tetrahedron *tet
-        cdef Real temp
         allocate_cross_sections(self.c_triangulation)
         compute_cross_sections(self.c_triangulation)
         compute_tilts(self.c_triangulation)

--- a/cython/core/pickle.pyx
+++ b/cython/core/pickle.pyx
@@ -92,7 +92,7 @@ cdef pickle_triangulation(c_Triangulation *tri):
     return result + bytes(tri_data.name)
 
 cdef pickle_tetrahedron_data(c_TetrahedronData* data, int flag):
-    cdef int i, j, k, v, f
+    cdef int i, j, v, f
     cdef Py_ssize_t n = 0
     cdef unsigned short mask, bit
     cdef int x, count, curve

--- a/cython/core/symmetry_group.pyx
+++ b/cython/core/symmetry_group.pyx
@@ -286,7 +286,6 @@ cdef class SymmetryGroup():
         >>> S.multiply_elements(2, 3)
         1
         """
-        cdef int prod
         order = self.order()
         for x in [i, j]:
             if not (0 <= x < order):

--- a/cython/core/tail.pyx
+++ b/cython/core/tail.pyx
@@ -259,22 +259,22 @@ def get_HT_knot_DT(crossings, alternation, index):
     DT = extract_HT_knot(record, crossings, alternation)
     return DT
 
+
 def get_HT_knot_by_index(alternation, index, manifold_class):
-    DT=[]
     crossings = 16
     if alternation == 'a':
-        for i in range(3,17):
+        for i in range(3, 17):
             if Alternating_offsets[i] > index:
                 crossings = i-1
                 break
         index_within_crossings = index - Alternating_offsets[crossings]
     elif alternation == 'n':
-        for i in range(8,17):
+        for i in range(8, 17):
             if Nonalternating_offsets[i] > index:
                 crossings = i-1
                 break
         index_within_crossings = index - Nonalternating_offsets[crossings]
-    name = '%d'%crossings + alternation + '%d'%(index_within_crossings + 1)
+    name = '%d' % crossings + alternation + '%d' % (index_within_crossings + 1)
     return manifold_class(name)
 
 #   Iterators
@@ -456,7 +456,7 @@ class ObsOrientableClosedCensus(Census):
         cdef Manifold result
         if isinstance(n, slice):
             return self.__class__(n.indices(self.length))
-        volume, num_tet, index, m, l = ObsOrientableClosedCensus.data[n].split()
+        _, num_tet, index, m, l = ObsOrientableClosedCensus.data[n].split()
         c_triangulation = GetCuspedCensusManifold(
             self.path, int(num_tet), self.orientability, int(index))
         if c_triangulation == NULL:
@@ -466,6 +466,7 @@ class ObsOrientableClosedCensus(Census):
         result.set_c_triangulation(c_triangulation)
         result.dehn_fill(( int(m),int(l)) )
         return result.with_hyperbolic_structure()
+
 
 class ObsNonorientableClosedCensus(Census):
     """
@@ -490,7 +491,7 @@ class ObsNonorientableClosedCensus(Census):
         cdef Manifold result
         if isinstance(n, slice):
             return self.__class__(n.indices(self.length))
-        volume, num_tet, index, m, l = ObsNonorientableClosedCensus.data[n].split()
+        _, num_tet, index, m, l = ObsNonorientableClosedCensus.data[n].split()
         c_triangulation = GetCuspedCensusManifold(
             self.path, int(num_tet), self.orientability, int(index))
         if c_triangulation == NULL:

--- a/cython/core/triangulation.pyx
+++ b/cython/core/triangulation.pyx
@@ -1038,7 +1038,7 @@ cdef class Triangulation():
                       other.cusp_info('is_complete') ):
             raise ValueError("Can't compare triangulations of manifolds "
                              "with Dehn fillings.")
-        return same_triangulation(self.c_triangulation, other.c_triangulation):
+        return same_triangulation(self.c_triangulation, other.c_triangulation)
 
     def __repr__(self):
         if self.c_triangulation is NULL:

--- a/cython/core/triangulation.pyx
+++ b/cython/core/triangulation.pyx
@@ -121,8 +121,6 @@ cdef class Triangulation():
               'link complement.')
 
     cdef get_triangulation(self, spec, remove_finite_vertices=True):
-        cdef Triangulation T
-
         # Step -1 Check for an entire-triangulation-file-in-a-string
         if isinstance(spec, bytes) and spec.startswith(b'pickle:'):
             return self._from_pickle(spec, remove_finite_vertices)
@@ -263,7 +261,6 @@ cdef class Triangulation():
             locations = [os.curdir, os.environ['SNAPPEA_MANIFOLD_DIRECTORY']]
         except KeyError:
             locations = [os.curdir]
-        found = 0
         for location in locations:
             pathname = os.path.join(location, name)
             if os.path.isfile(pathname):
@@ -1032,8 +1029,6 @@ cdef class Triangulation():
         >>> N == M
         ValueError: Can't compare triangulations of manifolds with Dehn fillings.
         """
-        cdef c_Triangulation *c_triangulation1
-        cdef c_Triangulation *c_triangulation2
         cdef Boolean answer
         if op != 2:
             return NotImplemented
@@ -1043,10 +1038,7 @@ cdef class Triangulation():
                       other.cusp_info('is_complete') ):
             raise ValueError("Can't compare triangulations of manifolds "
                              "with Dehn fillings.")
-        if same_triangulation(self.c_triangulation, other.c_triangulation):
-            return True
-        else:
-            return False
+        return same_triangulation(self.c_triangulation, other.c_triangulation):
 
     def __repr__(self):
         if self.c_triangulation is NULL:
@@ -2271,9 +2263,8 @@ cdef class Triangulation():
         >>> M.homology()
         Z/5 + Z
         """
-        cdef c_AbelianGroup *H
         cdef RelationMatrix R
-        cdef int m, n
+        cdef int n
 
         if self.c_triangulation is NULL:
             return AbelianGroup()

--- a/cython/core/triangulation.pyx
+++ b/cython/core/triangulation.pyx
@@ -958,12 +958,11 @@ cdef class Triangulation():
         return (result_cusp_indices, result_curves)
 
     def _get_tetrahedra_gluing_data(self):
-        cdef int i, j, k, v, f
+        cdef int i, j, k
         cdef TriangulationData* data
         triangulation_to_data(self.c_triangulation, &data)
         result = []
         for i from 0 <= i < data.num_tetrahedra:
-            tet = []
             neighbors = [data.tetrahedron_data[i].neighbor_index[j]
                          for j in range(4)]
             perms = [[data.tetrahedron_data[i].gluing[j][k]
@@ -1029,7 +1028,6 @@ cdef class Triangulation():
         >>> N == M
         ValueError: Can't compare triangulations of manifolds with Dehn fillings.
         """
-        cdef Boolean answer
         if op != 2:
             return NotImplemented
         if type(self) != type(other):
@@ -1038,7 +1036,8 @@ cdef class Triangulation():
                       other.cusp_info('is_complete') ):
             raise ValueError("Can't compare triangulations of manifolds "
                              "with Dehn fillings.")
-        return same_triangulation(self.c_triangulation, other.c_triangulation)
+        return bool(same_triangulation(self.c_triangulation,
+                                       other.c_triangulation))
 
     def __repr__(self):
         if self.c_triangulation is NULL:
@@ -1380,7 +1379,6 @@ cdef class Triangulation():
         else:
             raise ValueError("The method must be 'fold' or 'layered' or 'layered_and_marked'")
 
-        marked = True if mark_solid_tori else False
         c_new_tri = subdivide(self.c_triangulation, to_byte_str(self.name() + '_filled'))
         fill_cusp_spec = <Boolean*>malloc(n*sizeof(Boolean))
         for i in range(n):
@@ -2302,7 +2300,7 @@ cdef class Triangulation():
             pass
 
         cdef c_AbelianGroup *H
-        cdef int m, n
+        cdef int n
 
         if self.c_triangulation is NULL:
             return AbelianGroup()
@@ -2633,7 +2631,6 @@ cdef class Triangulation():
         of the geometric generators, for use in constructing a covering
         space.
         """
-        cdef c_Triangulation* cover
         cdef c_Triangulation* c_triangulation
         cdef c_GroupPresentation *c_group_presentation
         cdef RepresentationIntoSn* c_representation


### PR DESCRIPTION
found using
```
 cython-lint cython/ | grep "defined"
```
