### PR TITLE
some trivial fixes from cython-lint (indentation, raw strings, etc)

### DIFF
--- a/cython/SnapPy.pxi
+++ b/cython/SnapPy.pxi
@@ -761,43 +761,43 @@ cdef extern from "isomorphism_signature.h":
     extern c_Triangulation* triangulation_from_isomorphism_signature(char *isoSig)
 
 cdef extern from "ptolemy_types.h":
-     ctypedef char* Two_identified_variables[2]
+    ctypedef char* Two_identified_variables[2]
 
-     ctypedef struct Identification_of_variables:
-         int num_identifications
-         Two_identified_variables *variables
-         int *signs
-         int *powers
+    ctypedef struct Identification_of_variables:
+        int num_identifications
+        Two_identified_variables *variables
+        int *signs
+        int *powers
 
-     extern void free_identification_of_variables(Identification_of_variables id)
+    extern void free_identification_of_variables(Identification_of_variables id)
 
-     ctypedef struct Integer_matrix_with_explanations:
-         int **entries
-         int num_rows
-         int num_cols
-         char **explain_row
-         char **explain_column
+    ctypedef struct Integer_matrix_with_explanations:
+        int **entries
+        int num_rows
+        int num_cols
+        char **explain_row
+        char **explain_column
 
-     extern void free_integer_matrix_with_explanations(Integer_matrix_with_explanations m)
+    extern void free_integer_matrix_with_explanations(Integer_matrix_with_explanations m)
 
-     extern int number_of_edges(c_Triangulation *manifold)
+    extern int number_of_edges(c_Triangulation *manifold)
 
 cdef extern from "change_peripheral_curves_nonorientable.h":
-     extern c_FuncResult change_peripheral_curves_nonorientable( c_Triangulation *manifold, MatrixInt22 change_matrices[])
+    extern c_FuncResult change_peripheral_curves_nonorientable( c_Triangulation *manifold, MatrixInt22 change_matrices[])
 
 cdef extern from "gluing_equations_pgl.h":
-     extern void get_edge_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
-     extern void get_face_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
-     extern void get_internal_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
-     extern void get_cusp_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N, int cusp_num, int m, int l)
+    extern void get_edge_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
+    extern void get_face_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
+    extern void get_internal_gluing_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N)
+    extern void get_cusp_equations_pgl(c_Triangulation *manifold, Integer_matrix_with_explanations *m, int N, int cusp_num, int m, int l)
 
 cdef extern from "ptolemy_equations.h":
-     extern void get_ptolemy_equations_identified_coordinates(c_Triangulation *manifold, Identification_of_variables *id, int N, int* obstruction_class)
-     extern void get_ptolemy_equations_identified_face_classes(c_Triangulation *manifold, Identification_of_variables *id)
-     extern void get_ptolemy_equations_action_by_decoration_change(c_Triangulation *manifold, int N, Integer_matrix_with_explanations *m)
-     extern void get_ptolemy_equations_boundary_map_3(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
-     extern void get_ptolemy_equations_boundary_map_2(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
-     extern void get_ptolemy_equations_boundary_map_1(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
+    extern void get_ptolemy_equations_identified_coordinates(c_Triangulation *manifold, Identification_of_variables *id, int N, int* obstruction_class)
+    extern void get_ptolemy_equations_identified_face_classes(c_Triangulation *manifold, Identification_of_variables *id)
+    extern void get_ptolemy_equations_action_by_decoration_change(c_Triangulation *manifold, int N, Integer_matrix_with_explanations *m)
+    extern void get_ptolemy_equations_boundary_map_3(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
+    extern void get_ptolemy_equations_boundary_map_2(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
+    extern void get_ptolemy_equations_boundary_map_1(c_Triangulation *manifold, Integer_matrix_with_explanations *m)
 
 cdef extern from "inline.h":
     pass

--- a/cython/core/abelian_group.pyx
+++ b/cython/core/abelian_group.pyx
@@ -142,6 +142,7 @@ cdef class PresentationMatrix():
     A sparse representation of the presentation matrix of an abelian group.
     """
     cdef rows, cols, _row_support, _col_support, _entries, _units, dead_columns
+
     def __init__(self, rows, cols):
         self.rows = rows
         self.cols = cols

--- a/cython/core/basic.pyx
+++ b/cython/core/basic.pyx
@@ -27,8 +27,10 @@ try:
     from sage.interfaces.magma import magma
     try:
         from sage.interfaces.abc import GapElement, MagmaElement
+
         def is_GapElement(elt):
             return isinstance(elt, GapElement)
+
         def is_MagmaElement(elt):
             return isinstance(elt, MagmaElement)
     except:
@@ -83,6 +85,7 @@ except ImportError:
 cdef public UCS2_hack (char *string, Py_ssize_t length, char *errors) :
     return string
 
+
 def valid_index(i, n, format_str):
     """
     Return range(n)[i] or raises a nicely formatted IndexError
@@ -115,17 +118,25 @@ class MsgIO():
             self.write = sys.stdout.write
             self.flush = sys.stdout.flush
 
+
 msg_stream = MsgIO()
+
 
 # string testing for Python 3
 basestring = unicode = str
+
+
 def to_str(s):
     return s.decode()
+
+
 def bytearray_to_bytes(x):
     return bytes(x)
 
+
 def to_byte_str(s):
     return s.encode('utf-8') if type(s) != bytes else s
+
 
 # Types of covering spaces
 cover_types = {1:"irregular", 2:"regular", 3:"cyclic"}
@@ -152,12 +163,14 @@ Nonalternating_table = gzip.open(os.path.join(table_directory, 'nonalternating.g
 
 cdef public int SnapPy_test_flag = 0
 
+
 def set_test_flag(int value):
     cdef int old
     global SnapPy_test_flag
     old = SnapPy_test_flag
     SnapPy_test_flag = value
     return old
+
 
 # Implementation of the SnapPea UI functions and their global variables.
 cdef public void uFatalError(const_char_ptr function,
@@ -177,6 +190,7 @@ cdef public gLongComputationTicker
 # This enables a GUI to do updates during long computations.
 UI_callback = None
 
+
 def SnapPea_interrupt():
     """
     The UI can call this to stop SnapPea.  Returns True if SnapPea s busy.
@@ -188,6 +202,7 @@ def SnapPea_interrupt():
     if gLongComputationInProgress:
         gLongComputationCancelled = True
     return gLongComputationInProgress
+
 
 cdef public void uLongComputationBegins(const_char_ptr message,
                                         Boolean is_abortable):
@@ -245,8 +260,10 @@ cdef public int uQuery(const_char_ptr  message,
     sys.stderr.write('Q: %s\nA:  %s\n'%(<char *> message, default))
     return <int> default_response
 
+
 def cy_eval(s):
     return eval(s)
+
 
 def smith_form(M):
     if _within_sage:
@@ -288,9 +305,11 @@ SolutionType = ['not attempted', 'all tetrahedra positively oriented',
                 'unrecognized solution type', 'no solution found',
                 'tetrahedra shapes were inserted']
 
+
 # SnapPea memory usage
 def check_SnapPea_memory():
     verify_my_malloc_usage()
+
 
 def set_rand_seed(seed):
     """
@@ -298,6 +317,7 @@ def set_rand_seed(seed):
     triangulation moves.
     """
     srand(seed)
+
 
 # Ptolemy utility functions
 # convert and free an identification of variables structure
@@ -313,6 +333,7 @@ cdef convert_and_free_identification_of_variables(
                    to_str(c_vars.variables[i][0]),
                    to_str(c_vars.variables[i][1])))
     return var_list
+
 
 # convert and free an integer matrix from C
 cdef convert_and_free_integer_matrix(
@@ -378,9 +399,8 @@ class MatrixWithExplanations():
                 return repr(l)
 
             return "[ %s, ..., %s]" % (
-                ', '.join(map(repr,l[:3])),
-                ', '.join(map(repr,l[-3:])))
-
+                ', '.join(map(repr, l[:3])),
+                ', '.join(map(repr, l[-3:])))
 
         return (
             "%s(\n"
@@ -391,6 +411,7 @@ class MatrixWithExplanations():
                               '\n  '.join(repr(self.matrix).split('\n')),
                               format_explain_list(self.explain_columns),
                               format_explain_list(self.explain_rows))
+
 
 class NeumannZagierTypeEquations(MatrixWithExplanations):
 
@@ -408,6 +429,7 @@ class NeumannZagierTypeEquations(MatrixWithExplanations):
         return NeumannZagierTypeEquations(
             mat.matrix, mat.explain_rows, mat.explain_columns)
 
+
 from .number import Number as RawNumber
 
 # Conversions between various numerical types.
@@ -417,6 +439,7 @@ IF HIGH_PRECISION:
 ELSE:
     class Number(RawNumber):
         _default_precision=53
+
 
 cdef Real2gen_direct(Real R):
     """
@@ -467,7 +490,7 @@ cdef Complex2gen(Complex C):
     return pari.complex(real_part, imag_part)
 
 cdef RealImag2gen(Real R, Real I):
-        return pari.complex(Real2gen(R), Real2gen(I))
+    return pari.complex(Real2gen(R), Real2gen(I))
 
 cdef Complex2complex(Complex C):
     """
@@ -527,10 +550,10 @@ cdef Complex Object2Complex(obj):
     return result
 
 
-
 cdef double Real2double(Real R):
     cdef double* quad = <double *>&R
     return quad[0]
+
 
 cdef Complex gen2Complex(g):
     cdef Complex result
@@ -589,13 +612,17 @@ class Info(dict):
                 pass
         super(Info, self).__init__(content)
         self.__dict__.update(kwargs)
+
     def _immutable(self, *args):
         raise AttributeError('Info objects are immutable.')
+
     def keys(self):
         return self.__dict__.keys()
+
     __setattr__ = __delattr__ = __setitem__ = __delitem__ = _immutable
     pop = popitem = clear = update = _immutable
     _obsolete = {}
+
 
 class CuspInfo(Info):
     def __repr__(self):
@@ -613,6 +640,7 @@ class CuspInfo(Info):
                  'holonomy precision' : 'holonomy_accuracy',
                  'shape precision'    : 'shape_accuracy'}
 
+
 class DualCurveInfo(Info):
     def __repr__(self):
         return ('%3d: %s curve of length %s'%
@@ -620,8 +648,10 @@ class DualCurveInfo(Info):
     _obsolete = {'complete length' : 'complete_length',
                  'filled length' : 'filled_length'}
 
+
 def _StrLongestLen(l):
     return str(max(len(e) for e in l))
+
 
 LengthSpectrumFormatStringBase = (
     '%-4s '                                   # Multiplicity
@@ -638,6 +668,7 @@ LengthSpectrumFormatStringWithWord = (
     '%s')                                     # Word
 
 ShortMatrixParity = { MatrixParity[0] : '-', MatrixParity[1] : '+' }
+
 
 class LengthSpectrumInfo(Info):
     def __repr__(self):
@@ -664,16 +695,20 @@ class LengthSpectrumInfo(Info):
                 self.topology,
                 ShortMatrixParity[self.parity] )
 
+
 class ShapeInfo(Info):
     _obsolete = {'precision' : 'accuracies'}
+
     def __repr__(self):
         return repr(self.__dict__)
+
 
 class NormalSurfaceInfo(Info):
     def __repr__(self):
         orient = 'Orientable' if self.orientable else 'Non-orientable'
         sided = 'two-sided' if self.two_sided else 'one-sided'
         return '%s %s with euler = %s' % (orient, sided, self.euler)
+
 
 class LengthSpectrum(list):
     def __repr__(self):
@@ -685,9 +720,11 @@ class LengthSpectrum(list):
                 'mult', ' length', 'topology', 'parity')
         return '\n'.join([base] + [repr(s) for s in self])
 
+
 class ListOnePerLine(list):
     def __repr__(self):
         return '[' + ',\n '.join([repr(s) for s in self]) + ']'
+
 
 # Isometry
 
@@ -782,6 +819,7 @@ def _plink_callback(LE):
         manifold._cache.clear(message='plink_callback')
         msg_stream.write('\nNew triangulation received from PLink!\n')
 
+
 # Conversion functions Manifold <-> Triangulation
 
 def Manifold_from_Triangulation(Triangulation T, recompute=True,
@@ -808,6 +846,7 @@ def Manifold_from_Triangulation(Triangulation T, recompute=True,
     M.set_name(T.name())
     M._cover_info = T._cover_info
     return M
+
 
 def Triangulation_from_Manifold(Manifold M):
     cdef c_Triangulation *c_triangulation

--- a/cython/core/cusp_neighborhoods.pyx
+++ b/cython/core/cusp_neighborhoods.pyx
@@ -304,6 +304,7 @@ cdef class CCuspNeighborhood():
         else:
             raise RuntimeError('The HoroballViewer class was not imported.')
 
+
 class CuspNeighborhood(CCuspNeighborhood):
     """
     A CuspNeighborhood object represents an equivariant collection of

--- a/cython/core/dirichlet.pyx
+++ b/cython/core/dirichlet.pyx
@@ -322,11 +322,11 @@ cdef class CDirichletDomain():
         vertices = []
         vertex = vertex.next
         while vertex != &self.c_dirichlet_domain.vertex_list_end:
-          vertices.append(
-              ( self._number_(Real2Number(<Real>vertex.x[1])),
-                self._number_(Real2Number(<Real>vertex.x[2])),
-                self._number_(Real2Number(<Real>vertex.x[3])) ) )
-          vertex = vertex.next
+            vertices.append(
+                (self._number_(Real2Number(<Real>vertex.x[1])),
+                 self._number_(Real2Number(<Real>vertex.x[2])),
+                 self._number_(Real2Number(<Real>vertex.x[3]))) )
+            vertex = vertex.next
         return vertices
 
     def _vertex_data_list(self):
@@ -334,14 +334,14 @@ cdef class CDirichletDomain():
         vertices = []
         vertex = vertex.next
         while vertex != &self.c_dirichlet_domain.vertex_list_end:
-          vertices.append(
-              { 'position' : ( self._number_(Real2Number(<Real>vertex.x[1])),
+            vertices.append(
+                {'position': ( self._number_(Real2Number(<Real>vertex.x[1])),
                                self._number_(Real2Number(<Real>vertex.x[2])),
                                self._number_(Real2Number(<Real>vertex.x[3])) ),
-                'ideal' : bool(vertex.ideal),
-                'vertex_class' : vertex.v_class.index
-              })
-          vertex = vertex.next
+                  'ideal': bool(vertex.ideal),
+                  'vertex_class' : vertex.v_class.index
+                 })
+            vertex = vertex.next
         return vertices
 
     def _vertex_to_index_dict(self):
@@ -350,7 +350,7 @@ cdef class CDirichletDomain():
         """
         cdef WEVertex *vertex = &self.c_dirichlet_domain.vertex_list_begin
 
-        result = { }
+        result = {}
         index = 0
         vertex = vertex.next
         while vertex != &self.c_dirichlet_domain.vertex_list_end:
@@ -696,6 +696,7 @@ cdef class CDirichletDomain():
             for line in output:
                 if UI_callback is not None: UI_callback()
                 output_file.write(line)
+
 
 class DirichletDomain(CDirichletDomain):
     """

--- a/cython/core/manifold.pyx
+++ b/cython/core/manifold.pyx
@@ -76,7 +76,6 @@ cdef class Manifold(Triangulation):
       projection file.
     """
 
-
     def __init__(self, spec=None):
         if self.c_triangulation != NULL:
             self.init_hyperbolic_structure()
@@ -264,7 +263,6 @@ cdef class Manifold(Triangulation):
         Triangulation._from_string(self, string)
         if initialize_structure:
             self.init_hyperbolic_structure()
-
 
     def _from_bytes(self, bytestring, initialize_structure=True):
         """
@@ -507,7 +505,6 @@ cdef class Manifold(Triangulation):
             symmetry_group._set_c_symmetry_group(symmetries_of_manifold)
 
         return self._cache.save(symmetry_group, 'symmetry_group', of_link)
-
 
     def symmetric_triangulation(self):
         """
@@ -770,8 +767,8 @@ cdef class Manifold(Triangulation):
                      &accuracy,
                      &requires_initialization)
         if not is_known:
-           raise ValueError("The Chern-Simons invariant isn't "
-                            "currently known.")
+            raise ValueError("The Chern-Simons invariant isn't "
+                             "currently known.")
         cs = Real2Number(CS)
         cs.accuracy = accuracy
         return cs
@@ -967,12 +964,12 @@ cdef class Manifold(Triangulation):
 
         if part is not None:
             try:
-               return [a[part] for a in result]
+                return [a[part] for a in result]
             except KeyError:
                 raise ValueError('A non-existent shape data type '
                                  'was specified.')
         else:
-           return ListOnePerLine(result)
+            return ListOnePerLine(result)
 
     def _get_tetrahedra_shapes(self, which_solution):
         """
@@ -1578,7 +1575,6 @@ cdef class Manifold(Triangulation):
         except ValueError:
             pass
 
-
         if return_isometries:
             result = compute_isometries(self.c_triangulation,
                                         other.c_triangulation,
@@ -1840,8 +1836,8 @@ cdef class Manifold(Triangulation):
                 one_vertex_lengths = []
                 for f in range(4):
                     if v != f:
-                         one_vertex_lengths.append(self._number_(
-                             Real2Number(<Real>tet.cross_section.edge_length[v][f])))
+                        one_vertex_lengths.append(self._number_(
+                            Real2Number(<Real>tet.cross_section.edge_length[v][f])))
                     else:
                         one_vertex_lengths.append(None)
                 one_tet_lengths.append(one_vertex_lengths)

--- a/cython/core/symmetry_group.pyx
+++ b/cython/core/symmetry_group.pyx
@@ -78,9 +78,8 @@ cdef class SymmetryGroup():
         False
         """
         cdef c_AbelianGroup* abelian_description = NULL
-        ans = B2B(symmetry_group_is_abelian(
-                self.c_symmetry_group, &abelian_description))
-        return ans
+        return B2B(symmetry_group_is_abelian(
+            self.c_symmetry_group, &abelian_description))
 
     def abelian_description(self):
         """
@@ -97,12 +96,11 @@ cdef class SymmetryGroup():
             raise ValueError('The symmetry group is not abelian.')
 
         coeffs = []
-        for n from 0 <= n < A.num_torsion_coefficients:
-                coeffs.append(A.torsion_coefficients[n])
+        for n in range(A.num_torsion_coefficients):
+            coeffs.append(A.torsion_coefficients[n])
 
         # Don't need to free A as it is attached to the symmetry group object
         return AbelianGroup(elementary_divisors=coeffs)
-
 
     def is_dihedral(self):
         """

--- a/cython/core/tail.pyx
+++ b/cython/core/tail.pyx
@@ -1,22 +1,22 @@
 # get_triangulation
 
-split_filling_info = re.compile('(.*?)((?:\([0-9 .+-]+,[0-9 .+-]+\))*$)')
+split_filling_info = re.compile(r'(.*?)((?:\([0-9 .+-]+,[0-9 .+-]+\))*$)')
 is_torus_bundle = re.compile('b([+-no])([+-])([lLrR]+)$')
-is_link_complement1_pat = '(?P<crossings>[0-9]+)[\^](?P<components>[0-9]+)[_](?P<index>[0-9]+)$'
-is_link_complement2_pat = '(?P<crossings>[0-9]+)[_](?P<index>[0-9]+)[\^](?P<components>[0-9]+)$'
+is_link_complement1_pat = r'(?P<crossings>[0-9]+)[\^](?P<components>[0-9]+)[_](?P<index>[0-9]+)$'
+is_link_complement2_pat = r'(?P<crossings>[0-9]+)[_](?P<index>[0-9]+)[\^](?P<components>[0-9]+)$'
 is_link_complement3_pat = '[lL](?P<components>[0-9]{1})(?P<crossings>[0-9]{2})(?P<index>[0-9]+)$'
 is_link_complement1 = re.compile(is_link_complement1_pat)
 is_link_complement2 = re.compile(is_link_complement2_pat)
 is_link_complement3 = re.compile(is_link_complement3_pat)
 rolfsen_link_regexs = [is_link_complement1, is_link_complement2, is_link_complement3]
 is_HT_knot = re.compile('(?P<crossings>[0-9]+)(?P<alternation>[an])(?P<index>[0-9]+)$')
-is_braid_complement = re.compile('[Bb]raid[:]?(\[[0-9, \-]+\])$')
-is_int_DT_exterior = re.compile('DT[:]? *(\[[0-9, \-\(\)]+\](?: *, *\[[01, ]+\])?)$')
-is_alpha_DT_exterior = re.compile('DT[:\[] *([a-zA-Z]+(?:\.[01]+)?)[\]]?$')
-twister_word = '\[*([abcABC_\d!*]*|[abcABC_\d!,]*)\]*'
-is_twister_bundle = re.compile('Bundle\(S_\{(\d+),(\d+)\},'+twister_word+'\)')
-is_twister_splitting = re.compile('Splitting\(S_\{(\d+),(\d+)\},'+twister_word+','+twister_word+'\)')
-is_isosig = re.compile('([a-zA-Z0-9\+\-]+)$')
+is_braid_complement = re.compile(r'[Bb]raid[:]?(\[[0-9, \-]+\])$')
+is_int_DT_exterior = re.compile(r'DT[:]? *(\[[0-9, \-\(\)]+\](?: *, *\[[01, ]+\])?)$')
+is_alpha_DT_exterior = re.compile(r'DT[:\[] *([a-zA-Z]+(?:\.[01]+)?)[\]]?$')
+twister_word = r'\[*([abcABC_\d!*]*|[abcABC_\d!,]*)\]*'
+is_twister_bundle = re.compile(r'Bundle\(S_\{(\d+),(\d+)\},'+twister_word+r'\)')
+is_twister_splitting = re.compile(r'Splitting\(S_\{(\d+),(\d+)\},'+twister_word+','+twister_word+r'\)')
+is_isosig = re.compile(r'([a-zA-Z0-9\+\-]+)$')
 is_decorated_isosig = decorated_isosig.isosig_pattern
 
 # Hooks so that global module can monkey patch in modified versions
@@ -24,6 +24,7 @@ is_decorated_isosig = decorated_isosig.isosig_pattern
 
 _triangulation_class = Triangulation
 _manifold_class = Manifold
+
 
 def bundle_from_string(desc):
     desc = desc.replace(' ', '')
@@ -34,6 +35,7 @@ def bundle_from_string(desc):
         monodromy = monodromy.replace(',', '*').replace('_', '')
         surface = twister.Surface( (g, n) )
         return surface.bundle(monodromy, return_type='string')
+
 
 def splitting_from_string(desc):
     desc = desc.replace(' ', '')
@@ -46,7 +48,8 @@ def splitting_from_string(desc):
         surface = twister.Surface( (g, n) )
         return surface.splitting(gluing, handles, return_type='string')
 
-#Orientability.orientable = 0
+
+# Orientability.orientable = 0
 rev_spec_dict = {(5, 0) : 'm',
                  (5, 1) : 'm',
                  (6, 0) : 's',
@@ -108,6 +111,7 @@ cdef int set_cusps(c_Triangulation* c_triangulation, fillings) except -1:
                           Object2Real(meridian),
                           Object2Real(longitude))
     return 0
+
 
 # Testing code for get_triangulation
 def get_triangulation_tester():
@@ -190,6 +194,7 @@ def get_triangulation_tester():
         M = Triangulation(spec)
         print(M, M.homology())
 
+
 # Support for Hoste-Thistethwaite tables
 
 # These dictionaries are used in accessing the tables.  The key is the
@@ -204,7 +209,7 @@ Nonalternating_numbers = { 8:3, 9:8, 10:42, 11:185, 12:888, 13:5110,
 
 Alternating_offsets = {}
 offset = 0
-for i in range(3,17):
+for i in range(3, 17):
     Alternating_offsets[i] = offset
     offset +=  Alternating_numbers[i]
 Num_Alternating = offset
@@ -216,8 +221,9 @@ for i in range(8,17):
     offset += Nonalternating_numbers[i]
 Num_Nonalternating = offset
 
+
 def extract_HT_knot(record, crossings, alternation):
-    DT=[]
+    DT = []
     size = (1+crossings)//2
     for byte in record[:size]:
         first_nybble = (byte & 0xf0) >> 4
@@ -234,8 +240,9 @@ def extract_HT_knot(record, crossings, alternation):
                 DT[i] = -DT[i]
     return DT[:crossings]
 
+
 def get_HT_knot_DT(crossings, alternation, index):
-    size = (1 + crossings)//2
+    size = (1 + crossings) // 2
     index -= 1
     if ( alternation == 'a'
          and crossings in Alternating_numbers.keys()
@@ -277,6 +284,7 @@ def get_HT_knot_by_index(alternation, index, manifold_class):
     name = '%d' % crossings + alternation + '%d' % (index_within_crossings + 1)
     return manifold_class(name)
 
+
 #   Iterators
 
 class Census:
@@ -311,6 +319,7 @@ class Census:
     # subclasses override this
     def __getitem__(self, n):
         pass
+
 
 #  Cusped Census
 
@@ -350,6 +359,7 @@ five_tet_nonorientable = (
    377, 379, 380, 381, 382, 383, 384, 386, 387, 394, 396, 398, 399, 404,
    405, 406, 407, 408, 409, 411, 413, 414)
 
+
 class CuspedCensus(Census):
     """
     Base class for Iterators/Sequences for manifolds in the SnapPea
@@ -386,22 +396,22 @@ class CuspedCensus(Census):
         elif (self.orientability == Orientability.index('orientable')
               and (n - self.five_length - self.six_length -
                    self.seven_length < self.eight_length)):
-              census_index = (n - self.five_length - self.six_length
-                              - self.seven_length)
-              # Make this work without passing the spec to Manifold()
-              num = repr(census_index)
-              spec =  "t" + "0"*(5 - len(num)) + num
-              tarpath = "morwen8/" + spec
-              try:
-                  filedata = self.Census_Morwen8.extractfile(tarpath).read()
-                  c_triangulation = read_triangulation_from_string(filedata)
-              except:
-                  raise IOError('The Morwen 8 tetrahedra manifold %s '
-                                'was not found.'% spec)
-              result = Manifold(spec='empty')
-              result.set_c_triangulation(c_triangulation)
-              return result
-              ###return Manifold('t%d' % census_index)
+            census_index = (n - self.five_length - self.six_length
+                            - self.seven_length)
+            # Make this work without passing the spec to Manifold()
+            num = repr(census_index)
+            spec =  "t" + "0"*(5 - len(num)) + num
+            tarpath = "morwen8/" + spec
+            try:
+                filedata = self.Census_Morwen8.extractfile(tarpath).read()
+                c_triangulation = read_triangulation_from_string(filedata)
+            except:
+                raise IOError('The Morwen 8 tetrahedra manifold %s '
+                              'was not found.'% spec)
+            result = Manifold(spec='empty')
+            result.set_c_triangulation(c_triangulation)
+            return result
+            # return Manifold('t%d' % census_index)
         else:
             raise IndexError('Index is out of range.')
         c_triangulation = GetCuspedCensusManifold(
@@ -413,10 +423,12 @@ class CuspedCensus(Census):
         result.set_c_triangulation(c_triangulation)
         return result
 
+
 class ObsOrientableCuspedCensus(CuspedCensus):
     """
     Obsolete.
     """
+
 
 class ObsNonorientableCuspedCensus(CuspedCensus):
     """
@@ -430,6 +442,7 @@ class ObsNonorientableCuspedCensus(CuspedCensus):
 
     def lookup(self, n):
         return five_tet_nonorientable[n]
+
 
 # Closed Census (Obsolete)
 
@@ -502,6 +515,7 @@ class ObsNonorientableClosedCensus(Census):
         result.dehn_fill( (int(m),int(l)) )
         return result.with_hyperbolic_structure()
 
+
 # Knot tables
 
 class KnotExteriors(Census):
@@ -521,11 +535,13 @@ class KnotExteriors(Census):
         else:
             return get_HT_knot_by_index(self.alternation, n, _manifold_class)
 
+
 class AlternatingKnotExteriors(KnotExteriors):
     """
     Iterator/Sequence for Alternating knot exteriors from the
     Hoste-Thistlethwaite tables.   Goes through 16 crossings.
     """
+
 
 class NonalternatingKnotExteriors(KnotExteriors):
     """
@@ -538,7 +554,9 @@ class NonalternatingKnotExteriors(KnotExteriors):
     def __init__(self, indices=(0, sum(Nonalternating_numbers.values()), 1)):
         Census.__init__(self, indices)
 
+
 census_knot_numbers = [0, 0, 1, 2, 4, 22, 43, 129]
+
 
 class ObsCensusKnots(Census):
     """
@@ -595,19 +613,19 @@ class ObsLinkExteriors(Census):
     max_crossings = 11
 
     def __init__(self, components, indices=(0,10000,1)):
-         self.Christy_links = tarfile.open(link_archive, 'r:*')
+        self.Christy_links = tarfile.open(link_archive, 'r:*')
 
-         if not (1 <= components < len(self.num_links) ):
+        if not (1 <= components < len(self.num_links) ):
             raise IndexError('SnapPy has no data on links with '
                              '%s components.' % components)
 
-         self.components = components
+        self.components = components
 
-         self.length = sum(self.num_links[components])
+        self.length = sum(self.num_links[components])
 
-         Census.__init__(self, (indices[0],
-                                min(self.length, indices[1]),
-                                indices[2]))
+        Census.__init__(self, (indices[0],
+                               min(self.length, indices[1]),
+                               indices[2]))
 
     def __repr__(self):
         return ('Christy census of %s-component link complements '
@@ -639,11 +657,12 @@ class ObsLinkExteriors(Census):
                 result.set_name(name)
                 return result.with_hyperbolic_structure()
 
-#----------------------------------------------------------------
+
+# ----------------------------------------------------------------
 #
 #  Morwen's link table (data taken from Snap).  Now obsolete.
 #
-#----------------------------------------------------------------
+# ----------------------------------------------------------------
 
 class MorwenLinks:
     def __init__(self, num_components, num_crossings = None):
@@ -652,8 +671,10 @@ class MorwenLinks:
             'Please refer to the documentation for HTLinkExteriors.'
             )
 
+
 def left_pad_string(str,  length, pad=' '):
     return pad*(length - len(str)) + str
+
 
 class ObsMorwenLinks(Census):
     """
@@ -697,6 +718,7 @@ class ObsMorwenLinks(Census):
             result = Manifold(name)
             result.set_name(name)
             return result
+
 
 # Creating fibered manifolds from braids
 

--- a/cython/core/triangulation.pyx
+++ b/cython/core/triangulation.pyx
@@ -612,9 +612,9 @@ cdef class Triangulation():
             savefile = asksaveasfile(
                 mode='w', title='Save Triangulation', defaultextension='.tri',
                 filetypes = [
-                ('Triangulation and text files', '*.tri *.txt', 'TEXT'),
-                ('All text files', '', 'TEXT'),
-                ('All files', '')])
+                    ('Triangulation and text files', '*.tri *.txt', 'TEXT'),
+                    ('All text files', '', 'TEXT'),
+                    ('All files', '')])
             if savefile:
                 filename = savefile.name
                 savefile.close()
@@ -815,7 +815,6 @@ cdef class Triangulation():
         if remove_finite_vertices:
             self._remove_finite_vertices()
 
-
     def _from_isosig(self, isosig, remove_finite_vertices=True):
         """
         WARNING: Users should not use this function directly.  To
@@ -856,7 +855,6 @@ cdef class Triangulation():
 
         if decoration:
             decorated_isosig.set_peripheral_from_decoration(self, decoration)
-
 
     def __reduce__(self):
         """
@@ -934,25 +932,18 @@ cdef class Triangulation():
         triangulation_to_data(self.c_triangulation, &data)
 
         result_cusp_indices = []
-        for i from 0 <= i < self.num_tetrahedra():
-          row = []
-          for v from 0 <= v < 4:
-            row.append(
-               data.tetrahedron_data[i].cusp_index[v]
-               )
-          result_cusp_indices.append(row)
+        for i in range(self.num_tetrahedra()):
+            row = [data.tetrahedron_data[i].cusp_index[v]
+                   for v in range(4)]
+            result_cusp_indices.append(row)
 
         result_curves = []
-        for i from 0 <= i < self.num_tetrahedra():
-          for j from 0 <= j < 2:       # meridian, longitude
-            for k from 0 <= k < 2:     # righthanded, lefthanded
-              row = []
-              for v from 0 <= v < 4:
-                for f from 0 <= f < 4:
-                  row.append(
-                     data.tetrahedron_data[i].curve[j][k][v][f]
-                     )
-              result_curves.append(row)
+        for i in range(self.num_tetrahedra()):
+            for j in range(2):         # meridian, longitude
+                for k in range(2):     # righthanded, lefthanded
+                    data_ijk = data.tetrahedron_data[i].curve[j][k]
+                    row = [data_ijk[v][f] for v in range(4) for f in range(4)]
+                    result_curves.append(row)
 
         free_triangulation_data(data)
         return (result_cusp_indices, result_curves)
@@ -1384,7 +1375,6 @@ cdef class Triangulation():
         for i in range(n):
             fill_cusp_spec[i] = True
 
-
         close_cusps(c_new_tri, fill_cusp_spec, fill_by_fold, mark_solid_tori)
         number_the_tetrahedra(c_new_tri)
         number_the_edge_classes(c_new_tri)
@@ -1508,7 +1498,6 @@ cdef class Triangulation():
           * cusp gluing equations for longitudes: 'longitude'
         """
 
-
         cdef Integer_matrix_with_explanations c_matrix
 
         if N < 2 or N > 15:
@@ -1562,8 +1551,9 @@ cdef class Triangulation():
             for i in range(self.num_cusps()):
                 cusp_info = self.cusp_info(i)
 
-                to_do = [] # keep a todo list where we add (meridian,longitude)
-                           # pairs to process later
+                to_do = []
+                # keep a todo list where we add (meridian, longitude)
+                # pairs to process later
 
                 if cusp_info.is_complete:
 
@@ -1888,8 +1878,6 @@ cdef class Triangulation():
         class and 1 on the fourth face class but zero on every other of the
         four face classes.
         """
-
-
         return (
             ptolemyManifoldMethods.get_generalized_ptolemy_obstruction_classes(
                 self, N))
@@ -2556,6 +2544,7 @@ cdef class Triangulation():
                                           degree,
                                           strategy=strategy,
                                           num_threads=num_threads)
+
         def index(subgroup):
             return 1 if len(subgroup) == 0 else len(subgroup[0])
 
@@ -2870,7 +2859,6 @@ cdef class Triangulation():
             if result == func_bad_input:
                 raise ValueError('The peripheral data %s is not acceptable.' %
                                  peripheral_data)
-
 
     def has_finite_vertices(self):
         """


### PR DESCRIPTION
some fixes inside `cython` folder

- using `r"text"` in appropriate places
- fixing some wrong indentation
- also changes some old-style `for` loops to python-style (this may need a serious check at one place)

:pretzel: 