### PR TITLE
Allow 57 digits for `chern_simons` test on aarch64

### DIFF
--- a/cython/core/manifold.pyx
+++ b/cython/core/manifold.pyx
@@ -823,7 +823,7 @@ cdef class Manifold(Triangulation):
         is the number of digits of accuracy as *estimated* by SnapPea.
 
         >>> cs, accuracy = M.chern_simons(accuracy = True)
-        >>> accuracy in (8, 9, 56) # Low and High precision
+        >>> accuracy in (8, 9, 56, 57) # Low and High precision
         True
 
         By default, when the manifold has at least one cusp, Zickert's


### PR DESCRIPTION
On aarch64-linux, `ManifoldHP('m015').chern_simons(accuracy = True)` returns 57 digits of accuracy instead of 56.