### PR TITLE
Add snappy_11_tets and snappy_16_knots to known packages

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -436,7 +436,9 @@ snappy_module = sys.modules[__name__]
 database_objects = []
 known_manifold_packages = [('snappy_manifolds', True),
                            ('snappy_15_knots', False),
-                           ('nonexistent_manifolds', False)]
+                           ('nonexistent_manifolds', False),
+                           ('snappy_11_tets', False),
+                           ('snappy_16_knots', False)]
 
 for manifold_package, required in known_manifold_packages:
     table_dict = database.add_tables_from_package(manifold_package, required)

--- a/python/version.py
+++ b/python/version.py
@@ -1,2 +1,2 @@
-version = '3.31b'
+version = '3.3.1b1'
 release_date = 'January 2026'

--- a/python/version.py
+++ b/python/version.py
@@ -1,2 +1,2 @@
-version = '3.3'
+version = '3.31b'
 release_date = 'January 2026'


### PR DESCRIPTION
This is to let SnapPy automatically import [snappy_11_tets](https://github.com/Shakugannotorch/snappy_11_tets) and [snappy_16_knots](https://github.com/Shakugannotorch/snappy_16_knots) if they exist. No test fails on my machine with the up-to-date packages. 