### PR TITLE
Guard against Giac RUR crashes on large ideals

### DIFF
--- a/dev/extended_ptolemy/complexVolumesClosed.py
+++ b/dev/extended_ptolemy/complexVolumesClosed.py
@@ -43,7 +43,18 @@ def compute_representative_ptolemys_and_full_var_dict(M, precision = 53):
     I, full_var_dict = extended.ptolemy_ideal_for_filled(
         M, return_full_var_dict = 'data', notation = 'full')
 
-    rur = giac_rur.rational_univariate_representation(I)
+    try:
+        rur = giac_rur.rational_univariate_representation(I)
+    except giac_rur.GiacRURTooManyVariablesError as error:
+        raise ValueError(
+            "The extended Ptolemy ideal for this %d-tetrahedron "
+            "triangulation has %d variables. Giac %s's RUR "
+            "implementation crashes for more than %d variables, so this "
+            "Giac version limits this computation to triangulations with at "
+            "most 5 tetrahedra."
+            % (M.num_tetrahedra(), error.number_of_variables,
+               error.version_string,
+               giac_rur.GIAC_PRE_2_RUR_MAX_VARIABLES)) from None
 
     return [
         evaluate_at_roots(numberField, exact_values, precision)

--- a/dev/extended_ptolemy/giac_rur.py
+++ b/dev/extended_ptolemy/giac_rur.py
@@ -3,8 +3,36 @@ Sage convenience wrapper for Giac's rational univariate representation
 functionality.
 """
 
+import re
+
 from sage.all import QQ, PolynomialRing, NumberField
 from .giac_helper import giac
+
+# Giac before 2.0 corrupts memory in its RUR code above this variable count.
+GIAC_PRE_2_RUR_MAX_VARIABLES = 15
+
+
+class GiacRURTooManyVariablesError(ValueError):
+    def __init__(self, number_of_variables, version):
+        self.number_of_variables = number_of_variables
+        self.version = version
+        self.version_string = '.'.join(str(part) for part in version)
+        super().__init__(
+            "Giac %s's RUR implementation crashes for more than %d "
+            "variables, and this ideal has %d variables."
+            % (self.version_string, GIAC_PRE_2_RUR_MAX_VARIABLES,
+               number_of_variables))
+
+
+def _giac_version():
+    description = repr(giac('version()'))
+    match = re.search(
+        r'\bgiac\s+(\d+(?:\.\d+)+)', description, re.IGNORECASE)
+    if match is None:
+        raise RuntimeError('Could not determine Giac version from %s.'
+                           % description)
+    return tuple(int(part) for part in match.group(1).split('.'))
+
 
 # The main function of this file is:
 
@@ -60,6 +88,13 @@ def rational_univariate_representation(ideal):
 
     """
     R = ideal.ring()
+
+    number_of_variables = len(R.gens())
+    if number_of_variables > GIAC_PRE_2_RUR_MAX_VARIABLES:
+        version = _giac_version()
+        if version < (2, 0):
+            raise GiacRURTooManyVariablesError(
+                number_of_variables, version)
 
     # A "feature" introduced in Sage-9.4 is that
     # ideal.gens() vs R.gens()


### PR DESCRIPTION
## Summary

Giac versions before 2.0 corrupt memory when asked for a rational univariate
representation of an ideal in more than 15 variables. This change checks that
condition before calling Giac and raises a specific `ValueError` containing the
detected Giac version and the actual number of variables.

The closed extended-Ptolemy caller catches that specific exception and reports
the limitation in terms of the triangulation. Its ideal has
`2 * num_tetrahedra + 4` variables, so with an affected Giac version the
calculation is limited to triangulations with at most five tetrahedra.

Giac 2.0 and later are not subject to the check and continue through the
existing RUR implementation.

## Rationale

The RUR wrapper accepts arbitrary polynomial ideals and has non-Ptolemy
callers, so the generic error remains phrased in terms of variables. Only the
caller that has the manifold available translates the failure into
tetrahedron-specific language.

This deliberately does not modify the ideal, eliminate coordinates, or suggest
an in-place Giac upgrade that the surrounding Sage dependency set might not
support.

## Reproduction

The following Dockerfile installs the affected Sage, Giac, and released SnapPy
versions and runs the calculation on the six-tetrahedron triangulation of
`6_3(1,1)`:

```Dockerfile
# syntax=docker/dockerfile:1
FROM mambaorg/micromamba:2.8.1

RUN micromamba install --yes --name base --channel conda-forge \
        python=3.12 \
        sage=10.8 \
        giac=1.9.0.21 \
        pip \
    && micromamba clean --all --yes

ARG MAMBA_DOCKERFILE_ACTIVATE=1
RUN python -m pip install --no-cache-dir snappy==3.3.2

COPY --chown=$MAMBA_USER:$MAMBA_USER <<'PY' /tmp/reproduce.py
import snappy
from snappy.dev.extended_ptolemy import complexVolumesClosed
from snappy.dev.extended_ptolemy import extended

M = snappy.ManifoldHP('6_3')
M.dehn_fill((1, 1))
I = extended.ptolemy_ideal_for_filled(M)

print('tetrahedra:', M.num_tetrahedra(), flush=True)
print('variables:', len(I.ring().gens()), flush=True)
complexVolumesClosed.compute_representative_ptolemys_and_full_var_dict(M, 120)
PY

CMD ["python", "/tmp/reproduce.py"]
```

Build and run it:

```console
docker build -t snappy-giac-rur .
docker run --rm snappy-giac-rur
```

The container exits nonzero after reporting the triangulation size and Giac's
allocator failure:

```text
tetrahedra: 6
variables: 16
...
before (last 100 chars): b'sage3:=gbasis(sage0,sage1,sage2):;\r\nmalloc(): unaligned tcache chunk detected\r\n'
...
Giac crashed executing sage3:=gbasis(sage0,sage1,sage2):;
```

After this PR merges, the expected output of the above, when run with a SnapPy
release containing the change rather than the deliberately pinned 3.3.2
reproducer, is:

```text
tetrahedra: 6
variables: 16
Traceback (most recent call last):
...
ValueError: The extended Ptolemy ideal for this 6-tetrahedron triangulation has 16 variables. Giac 1.9.0's RUR implementation crashes for more than 15 variables, so this Giac version limits this computation to triangulations with at most 5 tetrahedra.
```

## Testing

- Existing `giac_rur.py` doctests: 17 passed.
- Giac 1.9: a 15-variable ideal completes; a 16-variable ideal raises the new
  exception before Giac is invoked.
- Giac 1.9 with `6_3(1,1)`: the closed-Ptolemy path reports six tetrahedra,
  16 variables, and the five-tetrahedron limit.
- Giac 2.0.0.19 with the unchanged `6_3(1,1)` ideal: the 16-variable RUR
  completes with component degrees `[6, 22]` and multiplicities `[1, 1]`.
